### PR TITLE
Getting specific revision for pocketsphinx-ruby gem to avoid error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'pocketsphinx-ruby'
+gem 'pocketsphinx-ruby', :github => 'watsonbox/pocketsphinx-ruby', :ref => 'f2f562b'
 gem 'espeak-ruby', :require=>"espeak"
 gem 'require_all'
 gem 'ordinator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git://github.com/watsonbox/pocketsphinx-ruby.git
+  revision: f2f562bdc66b86f08631a6bd9d348c73823a3d45
+  ref: f2f562b
+  specs:
+    pocketsphinx-ruby (0.3.0)
+      ffi (>= 1.9)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -5,9 +13,7 @@ GEM
     espeak-ruby (1.0.2)
     ffi (1.9.10)
     method_source (0.8.2)
-    ordinator (1.0.1)
-    pocketsphinx-ruby (0.3.0)
-      ffi (>= 1.9)
+    ordinator (1.0.2)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -21,7 +27,7 @@ PLATFORMS
 DEPENDENCIES
   espeak-ruby
   ordinator
-  pocketsphinx-ruby
+  pocketsphinx-ruby!
   pry
   require_all
 

--- a/charlie.rb
+++ b/charlie.rb
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require 'pocketsphinx-ruby'
 require 'pry'
 require 'ordinator'


### PR DESCRIPTION
Regarding #2. This should fix the issue with the pocketsphinx-ruby gem not having the `Decoder#unset_search` fix.
